### PR TITLE
Potential fix for code scanning alert no. 2: DOM text reinterpreted as HTML

### DIFF
--- a/akari_bot_webrender/templates/section_screenshot_evaluate.js
+++ b/akari_bot_webrender/templates/section_screenshot_evaluate.js
@@ -47,7 +47,6 @@ function section_screenshot_evaluate({ section, elements_to_disable }) {
   for (let i = 0; i < lazyimg.length; i++) {
     lazyimg[i].className = "image";
     const dataSrc = lazyimg[i].getAttribute("data-src");
-    // Allow only http, https or relative URLs for image src
     if (
       typeof dataSrc === "string" &&
       (dataSrc.startsWith("http://") ||
@@ -56,8 +55,7 @@ function section_screenshot_evaluate({ section, elements_to_disable }) {
     ) {
       lazyimg[i].src = dataSrc;
     } else {
-      // If not safe, skip assigning src
-      console.warn("Blocked suspicious data-src value for image:", dataSrc);
+      console.warn(`Blocked suspicious data-src value for image: ${dataSrc}`); // skipcq
     }
   }
 

--- a/akari_bot_webrender/templates/section_screenshot_evaluate.js
+++ b/akari_bot_webrender/templates/section_screenshot_evaluate.js
@@ -46,7 +46,19 @@ function section_screenshot_evaluate({ section, elements_to_disable }) {
   const lazyimg = nbox.querySelectorAll(".lazyload");
   for (let i = 0; i < lazyimg.length; i++) {
     lazyimg[i].className = "image";
-    lazyimg[i].src = lazyimg[i].getAttribute("data-src");
+    const dataSrc = lazyimg[i].getAttribute("data-src");
+    // Allow only http, https or relative URLs for image src
+    if (
+      typeof dataSrc === "string" &&
+      (dataSrc.startsWith("http://") ||
+        dataSrc.startsWith("https://") ||
+        dataSrc.startsWith("/"))
+    ) {
+      lazyimg[i].src = dataSrc;
+    } else {
+      // If not safe, skip assigning src
+      console.warn("Blocked suspicious data-src value for image:", dataSrc);
+    }
   }
 
   const new_parentNode = sec.parentNode.cloneNode();


### PR DESCRIPTION
Potential fix for [https://github.com/Teahouse-Studios/akari-bot-webrender/security/code-scanning/2](https://github.com/Teahouse-Studios/akari-bot-webrender/security/code-scanning/2)

To fix this problem, we should sanitize or validate the value of `data-src` before assigning it to the `src` attribute. Since the `src` attribute typically expects a URL, we should check that the `data-src` value is a safe, well-formed URL (either with a whitelist of schemes like `http`, `https`, or potentially relative URLs starting with `/`). We can use the browser's `URL` constructor (inside a try-catch block in case of invalid URLs), or write a simple regex-based check if we want to allow only specific patterns. The fix should be implemented directly in the assignment on line 49, in the file `akari_bot_webrender/templates/section_screenshot_evaluate.js`. No outside functionality is needed beyond the JS standard library.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
